### PR TITLE
Conform to changes to kwic function signatures

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -542,13 +542,13 @@ function app:show-hits($node as node()*, $model as map(*), $start as xs:integer,
 (:~
     Callback function called from the kwic module.
 :)
-declare %private function app:filter($node as node(), $mode as xs:string) as xs:string? {
+declare %private function app:filter($node as node(), $mode as xs:string) as text()? {
   if ($node/parent::tei:speaker or $node/parent::tei:stage or $node/parent::tei:head) then 
-      concat('(', $node, ':) ')
+      text { concat('(', $node, ':) ') }
   else if ($mode eq 'before') then 
-      concat($node, ' ')
+      text { concat($node, ' ') }
   else 
-      concat(' ', $node)
+      text { concat(' ', $node) }
 };
 
 declare function app:base($node as node(), $model as map(*)) {


### PR DESCRIPTION
`kwic:callback()` now expects `text()` instead of `xs:string`.

From the diff to https://github.com/eXist-db/exist/commit/051ba1e506f50c13ed3e3d81dbcb5efc579e4f36:

```
 -declare function kwic:callback($callback as function(*)?, $node as node(), $mode as xs:string) as xs:string? {
 +declare
 +    %private
 +function kwic:callback($callback as (function(text(), xs:string) as text()?)?, $node as text(), $mode as xs:string) as text()? {
```

Fixes https://github.com/eXist-db/exist/issues/1272.